### PR TITLE
Fix JSHint error. Fix PathKit support for web workers

### DIFF
--- a/src/libraries/util.js
+++ b/src/libraries/util.js
@@ -37,7 +37,7 @@ var flatten = function (arg) {
 		}
 	}
 	return args;
-} 
+};
 
 exports.randomGenerator = randomGenerator;
 exports.flatten = flatten;


### PR DESCRIPTION
When in a web worker, g.js fails to detect PathKit because it only checks in the `window` object, which is not available in web workers. This PR makes it also check in the `self` object. An better solution in the future would be to make this configurable via a new API